### PR TITLE
Move the proxy URL under the proxy module

### DIFF
--- a/project/apps/proxy/urls.py
+++ b/project/apps/proxy/urls.py
@@ -1,1 +1,10 @@
 from django.urls import re_path
+from apps.proxy.views import proxy_view
+
+
+urlpatterns = [
+
+# Main URL for the proxy app
+re_path(r'service/(?P<request_path>.*)', proxy_view, name="proxy_view"),
+
+]

--- a/project/apps/user_management/urls.py
+++ b/project/apps/user_management/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path, include
+from django.urls import path, re_path
 from apps.user_management.views.account_page import (
     AccountPageView,
     AccountEditView,
@@ -18,11 +18,9 @@ from apps.user_management.views.email_confirmation import (
     EmailConfirmationSentView,
     ResendVerificationEmailView,
 )
-from apps.proxy.views import proxy_view
 
 
 urlpatterns = [
-    re_path(r'service/(?P<request_path>.*)', proxy_view, name="proxy_view"),
 
     # ---- django.contrib.auth.urls.views ----
     path(

--- a/project/urls.py
+++ b/project/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     re_path("^$", ProfileRedirectView.as_view(), name="home"),
     path(r"admin/", admin.site.urls),
     path("", include("apps.user_management.urls")),
+    path("", include("apps.proxy.urls")),
     path(f"{settings.OPENID_URL_PREFIX}/", include("apps.identity_provider.urls")),
     path("", include("apps.privilege_manager.urls")),
     # expose it for browsable api


### PR DESCRIPTION
The Proxy URL was moved under the `proxy` module according to this [issue](https://github.com/geosolutions-it/djam/issues/43)