### PR TITLE
Help AuthKey digest multiple groups when doing apikey introspection

### DIFF
--- a/project/apps/identity_provider/views/geoserver_integration.py
+++ b/project/apps/identity_provider/views/geoserver_integration.py
@@ -131,7 +131,7 @@ class GeoserverAuthKeyAndApiKeyIntrospection(GeoserverIntrospection, views.APIVi
         user = get_user_model().objects.get(id=user_id)
         user_groups_names = user.get_team()
 
-        return Response({"username": user.username, "groups": user_groups_names,})
+        return Response({"username": user.username, "groups": [",".join(user_groups_names)]})
 
     def introspect_api_key(self, api_key_uuid):
         
@@ -139,7 +139,7 @@ class GeoserverAuthKeyAndApiKeyIntrospection(GeoserverIntrospection, views.APIVi
         user = api_key.user
         user_groups_names = user.get_team()
 
-        return Response({"username": user.username, "groups": user_groups_names,})
+        return Response({"username": user.username, "groups": [",".join(user_groups_names)]})
 
 
 class GeoserverCredentialsIntrospection(GeoserverIntrospection, views.APIView):


### PR DESCRIPTION
Geoserver AuthKey wasn't able to parse multiple groups returned inside the introspection response  because

- the [Group regex matcher](https://github.com/geoserver/geoserver/blob/main/src/extension/authkey/src/main/java/org/geoserver/security/WebServiceBodyResponseUserGroupService.java#L144-L150) for the AuthKey module can only parse multiple groups if set inside a single string (comma separated), e.g. e.g. "group_1, group_2"), because the matcher isn't iterated to parse additional matching groups
 - DJAM returns groups as a JSON array

With this PR we make DJAM return groups in a shape that AuthKey can parse them, i.e. in a single string.